### PR TITLE
Feature - Add formatted output for `cyquant.quantities.Quantity`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build/
 .tox/
 cyquant/__pycache__/
 tests/__pycache__/
+**.cp37-win_amd64.pyd
+**.cp38-win_amd64.pyd
+**.cp39-win_amd64.pyd

--- a/cyquant/format_quantity.py
+++ b/cyquant/format_quantity.py
@@ -145,9 +145,9 @@ def show_quantity(quantity: cyquant.quantities.Quantity, show_unit_symbol=True):
 
 		for idx, dim in enumerate(dims):
 			if bool_dims_list[idx]:
-				# use new update dict. operator in python 3.9+
-				dimensions_dict["dimensions"] |= {
-					dim: getattr(quantity.units.dimensions, dim)}
+				dimensions_dict["dimensions"].update(
+					{ dim: getattr(quantity.units.dimensions, dim) }
+				)
 		return dimensions_dict
 
 	def _dim2str(dimensions) -> str:

--- a/cyquant/format_quantity.py
+++ b/cyquant/format_quantity.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+import math
+import cyquant
+
+
+def _name_symbol(name, symbol):
+	return {
+		"name": name,
+		"symbol": symbol,
+	}
+
+
+def si_prefixes(scale: float, show_unit_symbol: bool) -> dict:
+	"""Prefix units with symbol or name
+
+	:param scale: 
+	:type scale: float
+	:param show_unit_symbol: Passed from `show_quantity`
+	:type show_unit_symbol: bool
+	:return: SI symbol and name
+	:rtype: dict
+	"""
+	if scale == 1.0:
+		return ""
+
+	scale = float(f"{scale:.3e}")
+	def ten_exp(exp): return 10 ** exp
+	prefixes = {
+		ten_exp(24): _name_symbol("yotta", "Y"),
+		ten_exp(21): _name_symbol("zetta", "Z"),
+		ten_exp(18): _name_symbol("exa", "E"),
+		ten_exp(15): _name_symbol("peta", "P"),
+		ten_exp(12): _name_symbol("tera", "T"),
+		ten_exp(9): _name_symbol("giga", "G"),
+		ten_exp(6): _name_symbol("mega", "M"),
+		ten_exp(3): _name_symbol("kilo", "k"),
+		ten_exp(2): _name_symbol("hecto", "h"),
+		ten_exp(1): _name_symbol("deka", "da"),
+		###### Beginning negatives #######
+		ten_exp(-1): _name_symbol("deci", "d"),
+		ten_exp(-2): _name_symbol("centi", "c"),
+		ten_exp(-3): _name_symbol("milli", "m"),
+		ten_exp(-6): _name_symbol("micro", "µ"),
+		ten_exp(-9): _name_symbol("nano", "n"),
+		ten_exp(-12): _name_symbol("pico", "p"),
+		ten_exp(-15): _name_symbol("femto", "f"),
+		ten_exp(-18): _name_symbol("atto", "a"),
+		ten_exp(-21): _name_symbol("zepto", "z"),
+		ten_exp(-24): _name_symbol("yocto", "y"),
+	}
+	prefix = prefixes.get(scale)
+	if not prefix:
+		raise ValueError("Unit prefix not found.")
+	return prefix["symbol"] if show_unit_symbol else prefix["name"]
+
+
+def si_unit_conversion(units: str) -> str:
+	"""Converts SI base units string into a
+		more readable unit of measurment.
+		e.g. [kg*m]/[(s^2)] -> N (for Newtons)
+			 [kg]/[m*(s^2)] -> Pa (for Pascals)
+
+	:param units: SI base units string
+	:type units: str
+	:return: Concise unit of measurement found in dict
+		returns keys: `name` and `symbol` else `None`
+	:rtype: dict_or_None
+	"""
+	conversions = {
+		"[kg*m]/[(s^2)]": _name_symbol("Newtons", "N"),
+		"[kg]/[m*(s^2)]": _name_symbol("Pascals", "Pa"),
+		"[kg*(m^2)]/[(s^2)]": _name_symbol("Joules", "J (N*m)"),
+		"[kg*(m^2)]/[(s^3)]": _name_symbol("Watts", "W"),
+		"[a*s]": _name_symbol("Coulombs", "C"),
+		"[kg*(m^2)]/[a*(s^3)]": _name_symbol("Volts", "V"),
+		"[(a^2)*(s^4)]/[kg*(m^2)]": _name_symbol("Farads", "F"),
+		"[kg*(m^2)]/[(a^2)*(s^3)]": _name_symbol("Ohms", "Ω"),
+		"[(a^2)*(s^3)]/[kg*(m^2)]": _name_symbol("Siemens", "S"),
+		"[kg*(m^2)]/[a*(s^2)]": _name_symbol("Webers", "Wb"),
+		"[kg]/[a*(s^2)]": _name_symbol("Teslas", "T"),
+		"[kg*(m^2)]/[(a^2)*(s^2)]": _name_symbol("Henrys", "H"),
+		"[(m^2)]/[(s^2)]": _name_symbol("Sieverts", "[J]/[kg]"),
+	}
+	return conversions.get(units, None)
+
+
+def show_quantity(quantity: cyquant.quantities.Quantity, show_unit_symbol=True):
+	"""Formats cyquant Quantity as string showing dimension abbreviation
+
+	:param quantity: cyquant quantity
+	:type quantity: class:`cyquant.quantities.Quantity`
+	:param show_unit_symbol: Shows unit symbol instead of name, defaults to False
+	:param show_unit_symbol: bool, optional
+	:return: Number as string (e.g. "23 m") or cyquant.quantities.Quantity
+	:rtype: str_or_class:`cyquant.quantities.Quantity`
+	"""
+	if type(quantity) in {float, int, None}:
+		return quantity
+	try:
+		# if `.units` attr cannot be extracted then
+		# pass quantity through
+		scale = quantity.units.scale
+	except Exception as e:
+		return quantity
+
+	dims = ["kg", "m", "s", "k", "a", "mol", "cd"]
+	units = {
+		"[kg]": "kg",
+		"[m]": "m" if show_unit_symbol else "meters",
+		"[s]": "s" if show_unit_symbol else "second(s)",
+		"[k]": "K" if show_unit_symbol else "Kelvin",
+		"[a]": "A" if show_unit_symbol else "amperes",
+		"[mol]": "mols",
+		"[cd]": "cd",  # candelas
+	}
+
+	def _show_units(dim: str) -> str:
+		"""Get dimension from units dict
+		
+		:return: Dimension Value from units dict
+			else return input `dim`
+		:rtype: str
+		"""
+		return units.get(dim, dim)
+
+	def _count_dimensions(quantity) -> int:
+		"""Checks how many dimensions are in the cyquant Quantity
+			and stores dimensions in dictionary
+
+		:return: Number of dimensions(units of measurement) in quantity
+			and key/val pairs of dim. names and their values.
+			keys: `count` & `dimensions`
+		:rtype: dict
+		"""
+		# '0' in dimensions means that unit of measurement isn't being used
+		# any dim. other than 0 represents the exponent of the unit
+		# e.g. Dimensions(kg=1,m=-1,s=-2,k=0,a=0,mol=0,cd=0) -> kg/m(s**2) or Pascals
+		#	   this would return 3 since there are three dimensions used
+		bool_dims_list = [
+			getattr(quantity.units.dimensions, dim) != 0 for dim in dims]
+		dimensions_dict = {
+			"count": sum(bool_dims_list),
+			"dimensions": {}
+		}
+
+		for idx, dim in enumerate(dims):
+			if bool_dims_list[idx]:
+				# use new update dict. operator in python 3.9+
+				dimensions_dict["dimensions"] |= {
+					dim: getattr(quantity.units.dimensions, dim)}
+		return dimensions_dict
+
+	def _dim2str(dimensions) -> str:
+		"""Converts `dimensions` from `_count_dimensions()`
+			into formatted string
+		"""
+		items = sorted(list(dimensions.items()))
+		positive_dims = []
+		negative_dims = []
+		for k, v in items:
+			val = k if abs(v) == 1 else f'({k}^{abs(int(v))})'
+			if v >= 0:
+				positive_dims.append(val)
+			else:
+				negative_dims.append(val)
+
+		def format_dims(dims): return f"[{'*'.join(dims)}]"
+		if positive_dims and negative_dims:
+			return format_dims(positive_dims) + "/" + format_dims(negative_dims)
+		elif positive_dims and not negative_dims:
+			return format_dims(positive_dims)
+		elif negative_dims and not positive_dims:
+			return f"[1]/{format_dims(negative_dims)}"
+		else:  # No dimensions in dict
+			return ""
+
+	def _quantity2str(quantity, scale, dimensions, prefix="") -> str:
+		"""Converts cyquant quantity to formatted string
+
+		:param quantity: cyquant quantity
+		:type quantity: class:`cyquant.quantities.Quantity`
+		:param scale: Scale of SIUnit
+		:type scale: float
+		:param dimensions: `dimensions` from `_count_dimensions()`
+		:type dimensions: dict
+		:param prefix: SI Unit prefix, defaults to ""
+		:type prefix: str, optional
+		:return: Formatted quantity_or_`cyquant.quantities.Quantity`
+		:rtype: str_or_class:`cyquant.quantities.Quantity`
+		"""
+		dims_len = len(dimensions.values())
+		q = float(quantity)
+		if dims_len == 1:
+			# get the only dim in dimensions dict
+			dim, exp = list(dimensions.items())[0]
+			dim_str = _dim2str(dimensions)
+			converted_dim = si_unit_conversion(dim_str)
+
+			if converted_dim:  # if converted, reset `dim_str`
+				dim_str = converted_dim["symbol"] if show_unit_symbol else converted_dim["name"]
+
+			u = dim_str if exp <= 0 else f"{_show_units(dim_str)}"
+			q_times_scale = q * scale
+
+			if scale == 1.0:  # no prefix case
+				return f"{q} {u}"
+			else:  # scale not 1.0
+				# If scale is not in kilograms -> use `grams`
+				if dim == "kg":
+					grams_scale = scale * 1000
+					new_prefix = si_prefixes(grams_scale, show_unit_symbol)
+					if show_unit_symbol:
+						return f"{q} {new_prefix}g"
+					else:
+						return f"{q} {new_prefix}grams"
+				elif dim in {"k", "mol", "cd"}:  # don't add prefix
+					return f"{q_times_scale:.3e} {_show_units(dim_str)}"
+				else:
+					return f"{q} {prefix}{u}" if prefix else f"{q_times_scale:.3e} {u}"
+
+		elif dims_len > 1:  # multiple dimensions in cyquant quantity
+			q_times_scale = q * scale
+			dim_str = _dim2str(dimensions)
+			converted_dim = si_unit_conversion(dim_str)
+			if converted_dim:
+				_units = converted_dim["symbol"] if show_unit_symbol else converted_dim["name"]
+				return f"{q_times_scale:.3e} {_units}"
+			else:
+				return f"{q_times_scale:.3e} {dim_str}"
+		else:
+			return quantity
+
+	dimensions_dict = _count_dimensions(quantity)
+	num_dims = dimensions_dict.get("count")
+	dimensions = dimensions_dict.get("dimensions")
+
+	if num_dims == 0:
+		# si units for degrees and radians may be returned here
+		if scale != 1.0:
+			q_times_scale = float(quantity) * scale
+			return f"{q_times_scale:.3e}"
+		else:
+			return f"{float(quantity)}"
+
+	def _is_scale_decimal(scale):
+		"""Checks if `scale` is a fraction
+			e.g. 1.0000 -> returns False
+			     0.0175 -> returns True
+
+		:return: `True` if decimal, else `False`
+		:rtype: bool
+		"""
+		return not scale - int(scale) == 0
+
+	prefix = ""
+	exp_greater_than_one = False
+	dim_list = list(dimensions.items())
+	for _, v in dim_list:
+		if v > 1:
+			exp_greater_than_one = True
+	# only add prefix if not base si unit and
+	# doesn't have exponent greater than 1
+	# case: Liters has m^3 and should not have prefix
+	if scale != 1.0 and not exp_greater_than_one:
+		def _is_power_of_ten(num) -> bool:
+			"""Is scale(`num`) base 10?"""
+			if num < 0:
+				return False
+			else:
+				# convert negative exponent scientific notation
+				# numbers into natural numbered exponents so
+				# the algorithm will work
+				num_list = []
+				sci_note_num = f"{num:.3e}"
+				num_list[:0] = sci_note_num
+				if "e" in num_list:
+					num_split = sci_note_num.split('e')
+					exp = abs(int(num_split[1]))
+					num = float(f"{num_split[0]}e{exp}")
+				power = int(math.log(num, 10) + 0.5)
+				return 10 ** power == num
+
+		if _is_power_of_ten(scale):
+			prefix = si_prefixes(scale, show_unit_symbol)
+
+	return _quantity2str(quantity, scale, dimensions, prefix)

--- a/tests/test_format_quantity.py
+++ b/tests/test_format_quantity.py
@@ -1,0 +1,126 @@
+from cyquant import si, Quantity, SIUnit, Dimensions
+from cyquant.format_quantity import show_quantity
+
+
+def test_show_quantity():
+	def _q(value: float, scale: float, dimensions: dict) -> Quantity:
+		"""Helper function to create cyquant quantities for testing"""
+		dims = {"kg": 0, "m": 0, "s": 0, "k": 0,
+                    "a": 0, "mol": 0, "cd": 0}
+
+		for dim in list(dimensions.keys()):
+			if dim not in {'kg', 'm', 's', 'k', 'a', 'mol', 'cd'}:
+				raise ValueError("Unrecognized Dimension")
+		dims.update(dimensions)
+
+		return Quantity(value, SIUnit(scale, Dimensions(
+			kg=dims.get("kg"), m=dims.get("m"), s=dims.get("s"),
+			k=dims.get("k"), a=dims.get("a"), mol=dims.get("mol"),
+			cd=dims.get("cd")
+		)))
+
+	# (si unit, expected value)
+	values = [
+		(1 * si.nano,  '1.000e-09'),
+		(1 * si.micro, '1.000e-06'),
+		(1 * si.milli, '1.000e-03'),
+		(1 * si.centi, '1.000e-02'),
+		(1 * si.deci, '1.000e-01'),
+		(1 * si.unity, '1.0'),
+		(1 * si.deca, '1.000e+01'),
+		(1 * si.hecta, '1.000e+02'),
+		(1 * si.kilo, '1.000e+03'),
+		(1 * si.mega,  '1.000e+06'),
+		(1 * si.giga,  '1.000e+09'),
+		(1 * si.tera,  '1.000e+12'),
+		(1 * si.meters,    '1.0 m'),
+		(1 * si.kilograms, '1.0 kg'),
+		(1 * si.seconds,   '1.0 s'),
+		(1 * si.kelvin,    '1.0 K'),
+		(1 * si.amperes,   '1.0 A'),
+		(1 * si.mols,     '1.0 mols'),
+		(1 * si.candelas, '1.0 cd'),
+		(1 * si.radians,  '1.0'),
+		(1 * si.radians,  '1.0'),
+		(1 * si.degrees,  '1.745e-02'),
+		(1 * si.hertz,   '1.0 [1]/[s]'),
+		(1 * si.newtons, '1.000e+00 N'),
+		(1 * si.pascals, '1.000e+00 Pa'),
+		(1 * si.joules,  '1.000e+00 J (N*m)'),
+		(1 * si.watts,   '1.000e+00 W'),
+		(1 * si.coulombs, '1.000e+00 C'),
+		(1 * si.volts,   '1.000e+00 V'),
+		(1 * si.farads,  '1.000e+00 F'),
+		(1 * si.ohms,    '1.000e+00 Ω'),
+		(1 * si.siemens, '1.000e+00 S'),
+		(1 * si.webers, '1.000e+00 Wb'),
+		(1 * si.teslas, '1.000e+00 T'),
+		(1 * si.henrys, '1.000e+00 H'),
+		(1 * si.lumens, '1.0 cd'),
+		(1 * si.becquerels, '1.0 [1]/[s]'),
+		(1 * si.sieverts,   '1.000e+00 [J]/[kg]'),
+		(1 * si.katals,     '1.000e+00 [mol]/[s]'),
+		(1 * si.nanometers, '1.0 nm'),
+		(1 * si.micrometers, '1.0 µm'),
+		(1 * si.millimeters, '1.0 mm'),
+		(1 * si.centimeters, '1.0 cm'),
+		(1 * si.decimeters, '1.0 dm'),
+		(1 * si.decameters, '1.0 dam'),
+		(1 * si.hectameters, '1.0 hm'),
+		(1 * si.kilometers, '1.0 km'),
+		(1 * si.liters,    '1.000e-03 [(m^3)]'),
+		(1 * si.grams,     '1.0 g'),
+		(1 * si.milligrams, '1.0 mg'),
+		(1 * si.micrograms, '1.0 µg'),
+		(1 * si.tonnes,    '1.0 Mg'),
+		(1 * si.kilotonnes, '1.0 Gg'),
+		(1 * si.nanoseconds, '1.0 ns'),
+		(1 * si.microseconds, '1.0 µs'),
+		(1 * si.milliseconds, '1.0 ms'),
+		(1 * si.minutes,      '6.000e+01 s'),
+		(1 * si.days,   '8.640e+04 s'),
+		(1 * si.weeks,   '6.048e+05 s'),
+		(1 * si.years,   '3.154e+07 s'),
+		(1 * si.gals,   '1.000e-02 [m]/[(s^2)]'),  # not gal -> galileos
+		(1 * si.g_0, '9.807e+00 [m]/[(s^2)]'),
+		(1 * si.micropascals, '1.000e-06 Pa'),
+		(1 * si.millipascals, '1.000e-03 Pa'),
+		(1 * si.kilopascals, '1.000e+03 Pa'),
+		(1 * si.megapascals, '1.000e+06 Pa'),
+		(1 * si.gigapascals, '1.000e+09 Pa'),
+		(1 * si.millijoules, '1.000e-03 J (N*m)'),
+		(1 * si.kilojoules,  '1.000e+03 J (N*m)'),
+		(1 * si.megajoules,  '1.000e+06 J (N*m)'),
+		(1 * si.gigajoules,  '1.000e+09 J (N*m)'),
+		(1 * si.terajoules,  '1.000e+12 J (N*m)'),
+		(1 * si.milliwatts,  '1.000e-03 W'),
+		(1 * si.kilowatts,   '1.000e+03 W'),
+		(1 * si.megawatts,   '1.000e+06 W'),
+		(1 * si.gigawatts,   '1.000e+09 W'),
+		(1 * si.terawatts,   '1.000e+12 W'),
+		(1 * si.millivolts,   '1.000e-03 V'),
+		(1 * si.kilovolts,   '1.000e+03 V'),
+		(1 * si.megavolts,   '1.000e+06 V'),
+		(1 * si.gigavolts,   '1.000e+09 V'),
+		(1 * si.teravolts,   '1.000e+12 V'),
+		(1 * si.micronewtons,   '1.000e-06 N'),
+		(1 * si.millinewtons,   '1.000e-03 N'),
+		(1 * si.kilonewtons,   '1.000e+03 N'),
+		(1 * si.newton_meters,   '1.000e+00 J (N*m)'),
+		(1 * si.kilonewton_meters,   '1.000e+03 J (N*m)'),
+		(1 * si.meters_per_second,   '1.000e+00 [m]/[s]'),
+		# Extra Tests #
+		(_q(0.0, 0.017453, {}), '0.000e+00'),
+		(_q(1.25, 10**-3, {"m": 1}), '1.25 mm'),
+	]
+
+	# Testing different units
+	# val = 1 * si.gigapascals
+	# print(val)
+	# print(show_quantity(val), type(show_quantity(val)))
+
+	for value in values:
+		tested = show_quantity(value[0])
+		expected = value[1]
+		error = f"{tested} != Expected Value: {expected} "
+		assert tested == expected, error

--- a/tests/test_format_quantity.py
+++ b/tests/test_format_quantity.py
@@ -13,11 +13,7 @@ def test_show_quantity():
 				raise ValueError("Unrecognized Dimension")
 		dims.update(dimensions)
 
-		return Quantity(value, SIUnit(scale, Dimensions(
-			kg=dims.get("kg"), m=dims.get("m"), s=dims.get("s"),
-			k=dims.get("k"), a=dims.get("a"), mol=dims.get("mol"),
-			cd=dims.get("cd")
-		)))
+		return Quantity(value, SIUnit(scale, Dimensions(**dims)))
 
 	# (si unit, expected value)
 	values = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37
+envlist = py37,py38,py39
 
 [testenv]
 extras = tests


### PR DESCRIPTION
# Changelog

- Add `show_quantity` function to **format_quantity.py** that does the following:
  - Formats values of class:`cyquant.quantities.Quantity`
  - Allows you to choose if you want the full unit of measurement name or just the symbol returned
  - Adds an SI unit prefix('giga','milli', etc) when possible
- Added test cases for each unit of measurement to **test_format_quantity.py**